### PR TITLE
Bump dependencies to latest (Feb 2025)

### DIFF
--- a/data-embed.cabal
+++ b/data-embed.cabal
@@ -1,5 +1,6 @@
 name:                data-embed
 version:             0.1.0.0
+x-revision:          3
 synopsis:            Embed files and other binary blobs inside executables without Template Haskell.
 description:         This package provides a Template Haskell-free alternative to <http://hackage.haskell.org/package/file-embed file-embed>. It provides a versioned, well defined binary format for embedded blobs, as well as library support and command line utilities for manipulating them.
 homepage:            https://github.com/valderman/data-embed
@@ -20,12 +21,12 @@ executable embedtool
     embedtool.hs
   build-depends:
     base            >=4.8   && <5,
-    cereal          >=0.4   && <0.5,
-    bytestring      >=0.10  && <0.11,
-    hashable        >=1.2   && <1.3,
-    containers      >=0.5   && <0.6,
+    cereal          >=0.4   && <0.6,
+    bytestring      >=0.10  && <0.13,
+    hashable        >=1.2   && <1.6,
+    containers      >=0.5   && <0.8,
     utf8-string     >=1.0   && <1.1,
-    directory       >=1.2   && <1.3,
+    directory       >=1.2   && <1.4,
     executable-path >=0.0.3 && <0.1
   default-language:
     Haskell2010
@@ -43,12 +44,12 @@ library
     BangPatterns
   build-depends:
     base            >=4.8   && <5,
-    cereal          >=0.4   && <0.5,
-    bytestring      >=0.10  && <0.11,
-    hashable        >=1.2   && <1.3,
-    containers      >=0.5   && <0.6,
+    cereal          >=0.4   && <0.6,
+    bytestring      >=0.10  && <0.13,
+    hashable        >=1.2   && <1.6,
+    containers      >=0.5   && <0.8,
     utf8-string     >=1.0   && <1.1,
-    directory       >=1.2   && <1.3,
+    directory       >=1.2   && <1.4,
     executable-path >=0.0.3 && <0.1
   default-language:
     Haskell2010


### PR DESCRIPTION
This package still builds fine with the latest dependencies, so I relaxed the bounds on Hackage:

  
 * Changed the library component&#39;s library dependency on &#39;bytestring&#39;
                          from `>=0.10 && <0.11`
                          to `>=0.10 && <0.13`

 * Changed the library component&#39;s library dependency on &#39;containers&#39;
                          from `>=0.5 && <0.7`
                          to `>=0.5 && <0.8`

 * Changed the library component&#39;s library dependency on &#39;hashable&#39;
                          from `>=1.2 && <1.3`
                          to `>=1.2 && <1.6`

 * Changed the executable &#39;embedtool&#39; component&#39;s library dependency on &#39;bytestring&#39;
                          from `>=0.10 && <0.11`
                          to `>=0.10 && <0.13`

 * Changed the executable &#39;embedtool&#39; component&#39;s library dependency on &#39;containers&#39;
                          from `>=0.5 && <0.7`
                          to `>=0.5 && <0.8`

 * Changed the executable &#39;embedtool&#39; component&#39;s library dependency on &#39;hashable&#39;
                          from `>=1.2 && <1.3`
                          to `>=1.2 && <1.6`

</ul>
